### PR TITLE
Add some Angular files to .dockerignore

### DIFF
--- a/web/frontend/angular/.dockerignore
+++ b/web/frontend/angular/.dockerignore
@@ -1,0 +1,14 @@
+# Exclude everything
+*
+
+# Make exceptions for what's needed
+!.browserslistrc
+!src
+!angular.json
+!extra-webpack.config.js
+!karma.conf.js
+!package.json
+!package-lock.json
+!tsconfig.app.json
+!tsconfig.json
+!tsconfig.spec.json


### PR DESCRIPTION
Fix #16

It didn't change the image size, but it did drastically improve the build time by avoiding the copy of node_modules. Of course, the size ends up being the same since it has to install the Angular dependencies in the container regardless.