### PR TITLE
Route the API endpoints

### DIFF
--- a/web/api/urls.py
+++ b/web/api/urls.py
@@ -1,7 +1,22 @@
 from django.urls import include, path
 from rest_framework import routers
 
+from .viewsets import (
+    DeviceViewSet,
+    NotificationSettingsViewSet,
+    ParameterViewSet,
+    TestHistoryViewSet,
+    TestViewSet,
+)
+
 router = routers.DefaultRouter()
+router.register("devices", DeviceViewSet, basename="device")
+router.register(
+    "notification_settings", NotificationSettingsViewSet, basename="notification_settings"
+)
+router.register("parameters", ParameterViewSet, basename="parameter")
+router.register("tests", TestViewSet, basename="test")
+router.register("test_history", TestHistoryViewSet, basename="test_history")
 
 urlpatterns = [
     path("", include(router.urls)),

--- a/web/urls.py
+++ b/web/urls.py
@@ -16,4 +16,8 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 
-urlpatterns = [path("admin/", admin.site.urls), path("", include("web.frontend.urls"))]
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("api/", include("web.api.urls")),
+    path("", include("web.frontend.urls")),
+]


### PR DESCRIPTION
You can confirm it works by sending a GET request to `http://127.0.0.1:8000/api/`. This should return a dictionary of supported endpoints:

```json
{
    "devices": "http://127.0.0.1:8000/api/devices/",
    "notification_settings": "http://127.0.0.1:8000/api/notification_settings/",
    "parameters": "http://127.0.0.1:8000/api/parameters/",
    "tests": "http://127.0.0.1:8000/api/tests/",
    "test_history": "http://127.0.0.1:8000/api/test_history/"
}
```

Note that user session authentication is enabled by default for all endpoints, so it may not be feasible to use them without first disabling that (comment out the `DEFAULT_AUTHENTICATION_CLASSES` key+value in `web/settings.py`). Even then, I think the endpoints rely on at least 1 user existing to work, and there's currently no endpoint for registering users (though I suppose one could be created tediously in the Django shell).