### PR TITLE
Fix Security Headers

### DIFF
--- a/web/middleware.py
+++ b/web/middleware.py
@@ -10,7 +10,23 @@ csp_policy = (
     .font_src("'self'", "fonts.gstatic.com")
     .style_src("'self'", "'unsafe-inline'", "fonts.googleapis.com")
 )
-secure_headers = secure.Secure(csp=csp_policy, permissions=secure.PermissionsPolicy())
+
+# Secure 0.3.0 mistakenly has a semicolon in the default value,
+# which is fixed in an unreleased version.
+permissions_policy = secure.PermissionsPolicy()
+permissions_policy.value = (
+    "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), "
+    "camera=(), clipboard-read=(), clipboard-write=(), cross-origin-isolated=(), "
+    "display-capture=(), document-domain=(), encrypted-media=(), "
+    "execution-while-not-rendered=(), execution-while-out-of-viewport=(), "
+    "fullscreen=(), gamepad=(), geolocation=(), gyroscope=(), magnetometer=(), "
+    "microphone=(), midi=(), navigation-override=(), payment=(), "
+    "picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), "
+    "speaker-selection=(), sync-xhr=(), usb=(), web-share=(), "
+    "xr-spatial-tracking=()"
+)
+
+secure_headers = secure.Secure(csp=csp_policy, permissions=permissions_policy)
 
 
 def set_secure_headers(get_response):

--- a/web/middleware.py
+++ b/web/middleware.py
@@ -2,16 +2,13 @@ import secure
 
 __all__ = ("set_secure_headers",)
 
+# Angular requires default-src 'self'; style-src 'self' 'unsafe-inline';
+# https://angular.io/guide/security#content-security-policy
 csp_policy = (
     secure.ContentSecurityPolicy()
-    .default_src("'none'")
-    .base_uri("'self'")
-    .connect_src("'self'")
-    .form_action("'self'")
-    .frame_ancestors("'self'")
-    .frame_src("'none'")
-    .style_src("'self'")
-    .img_src("'self'")
+    .default_src("'self'")
+    .font_src("'self'", "fonts.gstatic.com")
+    .style_src("'self'", "'unsafe-inline'", "fonts.googleapis.com")
 )
 secure_headers = secure.Secure(csp=csp_policy, permissions=secure.PermissionsPolicy())
 


### PR DESCRIPTION
* Adjust CSP so it meets Angular's minimum requirements
* Whitelist domains related to Google fonts
* Fix malformed Permission-Policy header (the default one mistakenly has a semicolon in it instead of a comma)

I'm not sure why, but all these issues seemed to crop up in Chromium, but not in Firefox. I didn't check if Angular even uses inline styles on Firefox like it does on Chromium. No idea why it let Google domains through.