### PR TITLE
Ensure a new device's owner is the current user

### DIFF
--- a/web/api/serializers/device.py
+++ b/web/api/serializers/device.py
@@ -4,6 +4,8 @@ from web.api.models import Device
 
 
 class DeviceSerializer(serializers.ModelSerializer):
+    owner = serializers.HiddenField(default=serializers.CurrentUserDefault())
+
     class Meta:
         model = Device
         fields = "__all__"


### PR DESCRIPTION
Ignore any value provided for the `owner` field and instead use a default value, which is the current user. DRF permits unknown fields, so it does not raise an error for `owner` despite it being hidden. This is not ideal, but it's not worth the effort to error for unknown fields.