### PR TITLE
Add filters to viewsets

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -97,15 +97,26 @@ docs = ["furo (>=2021.8.17b43,<2021.9.0)", "sphinx (>=3.5.0)", "sphinx-notfound-
 testing = ["coverage[toml] (>=5.0a4)", "pytest (>=4.6.11)"]
 
 [[package]]
+name = "django-filter"
+version = "21.1"
+description = "Django-filter is a reusable Django application for allowing users to filter querysets dynamically."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+Django = ">=2.2"
+
+[[package]]
 name = "django-rest-registration"
-version = "0.7.0"
+version = "0.7.2"
 description = "User registration REST API, based on django-rest-framework"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-Django = ">=1.10"
+Django = ">=2.0"
 djangorestframework = ">=3.3"
 
 [[package]]
@@ -168,7 +179,7 @@ tornado = ["tornado (>=0.2)"]
 
 [[package]]
 name = "identify"
-version = "2.4.11"
+version = "2.4.12"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -332,7 +343,7 @@ testing = ["django", "django-configurations (>=2.0)"]
 
 [[package]]
 name = "pytz"
-version = "2021.3"
+version = "2022.1"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -380,7 +391,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "virtualenv"
-version = "20.13.2"
+version = "20.14.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -410,7 +421,7 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.9"
-content-hash = "c9a88aff3bec08b7d70bfeae48b8b313d5fd9614763d4dd3955298d1b16e2752"
+content-hash = "6e08a026a95767c3d4a70041da6cfa30396cebc2b6661f6faa2460f73fce5884"
 
 [metadata.files]
 asgiref = [
@@ -480,9 +491,13 @@ django-environ = [
     {file = "django-environ-0.7.0.tar.gz", hash = "sha256:b99bd3704221f8b717c8517d8146e53fdee509d9e99056be560060003b92213e"},
     {file = "django_environ-0.7.0-py2.py3-none-any.whl", hash = "sha256:20a5a3570333d3718c0a7ca834290ef850e2b96237ae4ca0a05823b3a0cb3363"},
 ]
+django-filter = [
+    {file = "django-filter-21.1.tar.gz", hash = "sha256:632a251fa8f1aadb4b8cceff932bb52fe2f826dd7dfe7f3eac40e5c463d6836e"},
+    {file = "django_filter-21.1-py3-none-any.whl", hash = "sha256:f4a6737a30104c98d2e2a5fb93043f36dd7978e0c7ddc92f5998e85433ea5063"},
+]
 django-rest-registration = [
-    {file = "django-rest-registration-0.7.0.tar.gz", hash = "sha256:3c0e741d8acfbffabacb7fbba5c58190c7d0a1490ac23d46dccef6c640f1dc5c"},
-    {file = "django_rest_registration-0.7.0-py3-none-any.whl", hash = "sha256:e6024e3c6d711c930d7bebca08c15cf2270f8e8f6440cdb25a2d04cd9aea96f6"},
+    {file = "django-rest-registration-0.7.2.tar.gz", hash = "sha256:83996992658fe1f6ceb1fcd12ebad3a4deb11c6a8b993c5901c573b6c6f70aa4"},
+    {file = "django_rest_registration-0.7.2-py3-none-any.whl", hash = "sha256:79a7caca716b12a3bb616ac94321b778ff7027d481bed12752edc5ccfeba34e3"},
 ]
 django-webpack-loader = [
     {file = "django-webpack-loader-1.4.1.tar.gz", hash = "sha256:7e34085b7fc4d352e482ff9cf7d09ae4524e730675e25432ab1d25a2dd94e583"},
@@ -505,8 +520,8 @@ gunicorn = [
     {file = "gunicorn-20.1.0.tar.gz", hash = "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"},
 ]
 identify = [
-    {file = "identify-2.4.11-py2.py3-none-any.whl", hash = "sha256:fd906823ed1db23c7a48f9b176a1d71cb8abede1e21ebe614bac7bdd688d9213"},
-    {file = "identify-2.4.11.tar.gz", hash = "sha256:2986942d3974c8f2e5019a190523b0b0e2a07cb8e89bf236727fb4b26f27f8fd"},
+    {file = "identify-2.4.12-py2.py3-none-any.whl", hash = "sha256:5f06b14366bd1facb88b00540a1de05b69b310cbc2654db3c7e07fa3a4339323"},
+    {file = "identify-2.4.12.tar.gz", hash = "sha256:3f3244a559290e7d3deb9e9adc7b33594c1bc85a9dd82e0f1be519bf12a1ec17"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -645,8 +660,8 @@ pytest-django = [
     {file = "pytest_django-4.4.0-py3-none-any.whl", hash = "sha256:65783e78382456528bd9d79a35843adde9e6a47347b20464eb2c885cb0f1f606"},
 ]
 pytz = [
-    {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
-    {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
+    {file = "pytz-2022.1-py2.py3-none-any.whl", hash = "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"},
+    {file = "pytz-2022.1.tar.gz", hash = "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7"},
 ]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
@@ -700,8 +715,8 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.13.2-py2.py3-none-any.whl", hash = "sha256:e7b34c9474e6476ee208c43a4d9ac1510b041c68347eabfe9a9ea0c86aa0a46b"},
-    {file = "virtualenv-20.13.2.tar.gz", hash = "sha256:01f5f80744d24a3743ce61858123488e91cb2dd1d3bdf92adaf1bba39ffdedf0"},
+    {file = "virtualenv-20.14.0-py2.py3-none-any.whl", hash = "sha256:1e8588f35e8b42c6ec6841a13c5e88239de1e6e4e4cedfd3916b306dc826ec66"},
+    {file = "virtualenv-20.14.0.tar.gz", hash = "sha256:8e5b402037287126e81ccde9432b95a8be5b19d36584f64957060a3488c11ca8"},
 ]
 whitenoise = [
     {file = "whitenoise-5.3.0-py2.py3-none-any.whl", hash = "sha256:d963ef25639d1417e8a247be36e6aedd8c7c6f0a08adcb5a89146980a96b577c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 django = "~3.2.8"
 django-environ = "~0.7.0"
+django-filter = ">=21,<23"
 django-rest-registration = "~0.7"
 django-webpack-loader = "~1.4"
 djangorestframework = "~3.12.4"

--- a/web/api/viewsets/device.py
+++ b/web/api/viewsets/device.py
@@ -6,6 +6,7 @@ from web.api.serializers import DeviceSerializer
 
 class DeviceViewSet(viewsets.ModelViewSet):
     serializer_class = DeviceSerializer
+    filterset_fields = ["name"]
 
     def get_queryset(self):
         return Device.objects.filter(owner=self.request.user)

--- a/web/api/viewsets/notification_settings.py
+++ b/web/api/viewsets/notification_settings.py
@@ -6,6 +6,7 @@ from web.api.serializers import NotificationSettingsSerializer
 
 class NotificationSettingsViewSet(viewsets.ModelViewSet):
     serializer_class = NotificationSettingsSerializer
+    filterset_fields = ["test__id", "test__device__id", "destination"]
 
     def get_queryset(self):
         return NotificationSettings.objects.filter(test__device__owner=self.request.user)

--- a/web/api/viewsets/parameter.py
+++ b/web/api/viewsets/parameter.py
@@ -6,6 +6,7 @@ from web.api.serializers import ParameterSerializer
 
 class ParameterViewSet(viewsets.ModelViewSet):
     serializer_class = ParameterSerializer
+    filterset_fields = ["test__id", "test__device__id", "name", "unit", "is_manual"]
 
     def get_queryset(self):
         return Parameter.objects.filter(test__device__owner=self.request.user)

--- a/web/api/viewsets/test.py
+++ b/web/api/viewsets/test.py
@@ -1,4 +1,5 @@
-from rest_framework import viewsets
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import filters, viewsets
 
 from web.api.models import Test
 from web.api.serializers import TestSerializer
@@ -6,6 +7,15 @@ from web.api.serializers import TestSerializer
 
 class TestViewSet(viewsets.ModelViewSet):
     serializer_class = TestSerializer
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
+    filterset_fields = [
+        "name",
+        "created_at",
+        "frequency",
+        "device__id",
+    ]
+    ordering_fields = ["created_at"]
+    ordering = ["created_at"]
 
     def get_queryset(self):
         return Test.objects.filter(device__owner=self.request.user)

--- a/web/api/viewsets/test_history.py
+++ b/web/api/viewsets/test_history.py
@@ -1,4 +1,5 @@
-from rest_framework import viewsets
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import filters, viewsets
 
 from web.api.models import TestHistory
 from web.api.serializers import TestHistorySerializer
@@ -6,6 +7,10 @@ from web.api.serializers import TestHistorySerializer
 
 class TestHistoryViewSet(viewsets.ModelViewSet):
     serializer_class = TestHistorySerializer
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
+    filterset_fields = ["test__id", "test__device__id", "started_at", "ended_at", "status"]
+    ordering_fields = ["started_at", "ended_at"]
+    ordering = ["ended_at"]
 
     def get_queryset(self):
         return TestHistory.objects.filter(test__device__owner=self.request.user)

--- a/web/settings.py
+++ b/web/settings.py
@@ -61,6 +61,7 @@ DJANGO_APPS = [
 THIRD_PARTY_APPS = [
     "webpack_loader",
     "rest_registration",
+    "django_filters",
 ]
 
 LOCAL_APPS = [
@@ -86,6 +87,7 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.SessionAuthentication",
     ],
+    "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
     "DEFAULT_PARSER_CLASSES": ("drf_orjson_renderer.parsers.ORJSONParser",),
     "ORJSON_RENDERER_OPTIONS": (
         orjson.OPT_NON_STR_KEYS,


### PR DESCRIPTION
This adds filtering capabilities to endpoints. Each endpoint has a set of fields by which filtering is permitted. This is a simple equality filter (i.e. the value given has to exactly match the value of the field). 

For example, `http://127.0.0.1:8000/api/tests/?device__id=2&name=test_01` returns tests named `test_01` which are for the device with an ID of `2`. To see all available fields for filtering, refer to the `filterset_fields` list in each viewset.

Some endpoints also have support for ordering. For example, `http://127.0.0.1:8000/api/test_history/?ordering=started_at`. This can be combined with filters. To see more information, refer to the [docs](https://www.django-rest-framework.org/api-guide/filtering/#orderingfilter). To see all available fields for ordering, refer to the `ordering_fields` in each viewset.