### PR TITLE
Fix encoding/decoding for OrjsonField

### DIFF
--- a/web/utils/fields.py
+++ b/web/utils/fields.py
@@ -1,8 +1,9 @@
-import orjson
 from django import forms
 from django.contrib.postgres.fields import ArrayField
 from django.core import exceptions
 from django.db import models
+
+from web.utils import json
 
 __all__ = ("ChoiceArrayField", "NullEmailField")
 
@@ -53,8 +54,8 @@ class OrjsonField(models.JSONField):
     """A JSONField which uses orjson for encoding/decoding."""
 
     def __init__(self, verbose_name=None, name=None, **kwargs):
-        kwargs["encoder"] = orjson.dumps
-        kwargs["decoder"] = orjson.loads
+        kwargs["encoder"] = json.OrjsonEncoder
+        kwargs["decoder"] = json.OrjsonDecoder
         super().__init__(verbose_name, name, **kwargs)
 
 

--- a/web/utils/json.py
+++ b/web/utils/json.py
@@ -1,0 +1,46 @@
+import json
+import typing
+
+import orjson
+
+
+class OrjsonDecoder(json.JSONDecoder):
+    """JSONDecoder which uses orjson.
+
+    None of the keyword arguments are supported, though they can still be specified to maintain
+    compatibility with the default interface.
+
+    `raw_decode` is not implemented in orjson, so the standard json implementation is used.
+    """
+
+    def decode(self, s: str) -> typing.Any:
+        return orjson.loads(s)
+
+
+class OrjsonEncoder(json.JSONEncoder):
+    """JSONEncoder which uses orjson.
+
+    `iterencode` is not implemented in orjson, so the standard json implementation is used.
+    """
+
+    def __init__(self, *, option: int = 0, **kwargs):
+        """Initialises the OrjsonEncoder.
+
+        Accepts the same keyword arguments as `json.JSONEncoder`, but most won't actually do
+        anything due to lack of support in orjson. The exceptions are `sort_keys` and `default`,
+        which are fully supported, and `indent`, which will always use an indent of 2 if non-zero.
+
+        orjson-specific options can be given with the `option` keyword argument.
+        """
+        super().__init__(**kwargs)
+
+        self.option = option
+
+        if self.sort_keys:
+            self.option |= orjson.OPT_SORT_KEYS
+
+        if self.indent:
+            self.option |= orjson.OPT_INDENT_2
+
+    def encode(self, o: typing.Any) -> str:
+        return orjson.dumps(o, option=self.option, default=self.default).decode("utf8")


### PR DESCRIPTION
The encoder and decoder are expected to be objects following the `JSONEncoder` and `JSONDecoder` interfaces, respectively. Thus, the orjson `dumps` and `loads` functions cannot be used directly.

Define `JSONEncoder` and `JSONDecoder` subclasses which wrap orjson, and use these as the encoder and decoder for `OrjsonField`.

This field was only used by the `/api/notification_settings/` settings endpoint, so that endpoint should now be able to work. Previously, it always reported a JSON validation error for the `condition` field. To test it, the following code can be used

```js
(async () => {
    let response = await fetch(
        "/api/notification_settings/",
        {
            method: "POST",
            headers: {
                'Accept': 'application/json',
                'Content-Type': 'application/json',
                'X-CSRFToken': getCookie('csrftoken'),
            },
            mode: 'same-origin',
            body: JSON.stringify({
                condition: {"var": 1},
                destination: ["EM", "WE"],
                test: 1, // This test needs to be created beforehand
                message: "hello"
            }),
        }
    );
    let content = await response.json();
    console.log(content);
})();
```